### PR TITLE
Fix NullPointerException When OpenAPI Definition Lacks Components

### DIFF
--- a/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/utils/ProjectGeneratorUtils.java
+++ b/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/utils/ProjectGeneratorUtils.java
@@ -96,7 +96,9 @@ public class ProjectGeneratorUtils {
                 String pathToResourcesDir = pathToConnectorDir + "/src/main/resources";
                 createConnectorDirectory(pathToConnectorDir, pathToMainDir, pathToResourcesDir, connectorName);
                 copyConnectorStaticFiles(pathToConnectorDir, pathToResourcesDir, pathToMainDir);
-                componentsSchema = openAPI.getComponents().getSchemas();
+                if (openAPI.getComponents() != null) {
+                    componentsSchema = openAPI.getComponents().getSchemas();
+                }
                 readOpenAPISpecification(openAPI, pathToResourcesDir);
                 operationList.sort(Comparator.comparing(Operation::getName));
                 context.put("operations", operationList);


### PR DESCRIPTION
#### Related Issues  
- https://github.com/wso2/product-micro-integrator/issues/4013

#### Description  
This PR fixes a `NullPointerException` encountered when generating a connector from an OpenAPI definition that lacks components. The issue arises because the `getComponents()` method returns `null`, and the code attempts to invoke `getSchemas()` on that `null` value.

#### Fix  
- Added a null check for the components in the OpenAPI definition to prevent the code from attempting to access `getSchemas()` when components are absent.  
