### PR TITLE
Add Server URL from OAS as Default BaseURL During Connection Setup

### DIFF
--- a/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/utils/ProjectGeneratorUtils.java
+++ b/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/utils/ProjectGeneratorUtils.java
@@ -636,10 +636,15 @@ public class ProjectGeneratorUtils {
             context.put("auth", "noauth");
         }
 
+        if (openAPI.getServers() != null && !openAPI.getServers().isEmpty() && openAPI.getServers().get(0) != null) {
+            context.put("defaultUrl", openAPI.getServers().get(0).getUrl());
+        } else {
+            context.put("defaultUrl", "");
+        }
+
         context.put("version", "1.0.0");
         context.put("groupId", "org.wso2.mi.connector");
         context.put("connectorName", resolvedConnectorName);
-        context.put("defaultUrl", openAPI.getServers().get(0).getUrl());
         return context;
     }
     private static String makePackageNameCompatible(String name) {

--- a/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/utils/ProjectGeneratorUtils.java
+++ b/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/utils/ProjectGeneratorUtils.java
@@ -639,6 +639,7 @@ public class ProjectGeneratorUtils {
         context.put("version", "1.0.0");
         context.put("groupId", "org.wso2.mi.connector");
         context.put("connectorName", resolvedConnectorName);
+        context.put("defaultUrl", openAPI.getServers().get(0).getUrl());
         return context;
     }
     private static String makePackageNameCompatible(String name) {

--- a/src/main/resources/templates/uischema/init_api_key_auth_template.vm
+++ b/src/main/resources/templates/uischema/init_api_key_auth_template.vm
@@ -32,7 +32,7 @@
                               "name":"base",
                               "displayName":"Base URL",
                               "inputType":"stringOrExpression",
-                              "defaultValue":"${defaultUrl}",
+                              "defaultValue":"$defaultUrl",
                               "required":"true",
                               "helpTip":"The service root URL."
                            }

--- a/src/main/resources/templates/uischema/init_basic_auth_template.vm
+++ b/src/main/resources/templates/uischema/init_basic_auth_template.vm
@@ -39,7 +39,7 @@
                                         "name" : "base",
                                         "displayName" : "Base URL",
                                         "inputType" : "stringOrExpression",
-                                        "defaultValue" : "",
+                                        "defaultValue" : "$defaultUrl",
                                         "required" : "true",
                                         "helpTip" : "The service root URL."
                                     }

--- a/src/main/resources/templates/uischema/init_no_auth_template.vm
+++ b/src/main/resources/templates/uischema/init_no_auth_template.vm
@@ -32,7 +32,7 @@
                                         "name": "base",
                                         "displayName": "Base URL",
                                         "inputType": "stringOrExpression",
-                                        "defaultValue": "",
+                                        "defaultValue": "$defaultUrl",
                                         "required": "true",
                                         "helpTip": "The service root URL."
                                     }


### PR DESCRIPTION
#### Related Issues  

- https://github.com/wso2/product-micro-integrator/issues/4006

#### Description  
This PR introduces functionality to automatically use the base URL from the OpenAPI specification as the default during the connection setup for custom connectors. Currently, the base URL is a mandatory configuration during the connection setup, even when it is already defined in the OpenAPI definition. 

<img width="706" alt="Screenshot 2025-02-14 at 13 10 30" src="https://github.com/user-attachments/assets/ef73f629-1778-4a70-9ec0-94367c3cfcff" />


This change skips the manual input of the base URL and makes the configuration optional if the OpenAPI definition contains a valid base URL.