### PR TITLE
Add Support for Maven 3.9.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ target
 target/
 *.*~
 /.metadata/
+.vscode/settings.json

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8.1</version>
+            <version>3.17.0</version>
         </dependency>
     </dependencies>
     <pluginRepositories>

--- a/src/main/resources/connector-files/src/main/assembly/filter.properties
+++ b/src/main/resources/connector-files/src/main/assembly/filter.properties
@@ -17,4 +17,4 @@
 #
 
 product.name=WSO2 MI
-product.version=4.3.0
+product.version=4.4.0

--- a/src/main/resources/templates/synapse/pom_template.vm
+++ b/src/main/resources/templates/synapse/pom_template.vm
@@ -85,7 +85,7 @@
                         <id>build-connector</id>
                         <phase>compile</phase>
                         <goals>
-                            <goal>attached</goal>
+                            <goal>single</goal>
                         </goals>
                         <configuration>
                             <finalName>${connector.name}-${project.version}</finalName>


### PR DESCRIPTION
#### Related Issues  
- https://github.com/wso2-enterprise/vscode-extensions/issues/4700

#### Description  

This PR addresses an issue where the connector import with an OpenAPI definition works with Maven 3.5.0 but fails with Maven 3.9.4. 

This update adds support for Maven 3.9.x to ensure that the connector import process works seamlessly across both Maven versions.
