### PR TITLE
Add RT version based generation for ResponseModel

### DIFF
--- a/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/ConnectorGenerator.java
+++ b/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/ConnectorGenerator.java
@@ -31,12 +31,17 @@ public class ConnectorGenerator {
      * @param args The arguments.
      */
     public static void main(String[] args) {
-        if (args.length != 2) {
-            throw new IllegalArgumentException("Usage: <openapi-spec> <output-dir>");
+        if (args.length < 2 || args.length > 3) {
+            throw new IllegalArgumentException("Usage: <openApiSpec> <outputDir> [miVersion]");
         }
         String openApiSpec = args[0];
         String outputDir = args[1];
-        generateConnector(openApiSpec, outputDir);
+        String miVersion = null;
+        if (args.length == 3) {
+            miVersion = args[2];
+        }
+
+        generateConnector(openApiSpec, outputDir, miVersion);
     }
 
     /**
@@ -46,10 +51,14 @@ public class ConnectorGenerator {
      * @param outputDir The output directory.
      * @return The path to the generated connector.
      */
-    public static String generateConnector(String openApiSpec, String outputDir) {
+    // Add miVersion default value to 4.4.0
+    public static String generateConnector(String openApiSpec, String outputDir, String miVersion) {
+        if (miVersion == null) {
+            miVersion = "4.4.0";
+        }
         String connectorPath;
         try {
-            String connectorProjectDir = ProjectGeneratorUtils.generateConnectorProject(openApiSpec, outputDir);
+            String connectorProjectDir = ProjectGeneratorUtils.generateConnectorProject(openApiSpec, outputDir,miVersion);
             connectorPath =  ConnectorBuilderUtils.buildConnector(connectorProjectDir);
         } catch (ConnectorGenException e) {
             throw new RuntimeException("Error occurred while generating the connector", e);

--- a/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/ConnectorGenerator.java
+++ b/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/ConnectorGenerator.java
@@ -36,10 +36,7 @@ public class ConnectorGenerator {
         }
         String openApiSpec = args[0];
         String outputDir = args[1];
-        String miVersion = null;
-        if (args.length == 3) {
-            miVersion = args[2];
-        }
+        String miVersion = args.length == 3 ? args[2] : "4.4.0";
 
         generateConnector(openApiSpec, outputDir, miVersion);
     }
@@ -51,15 +48,27 @@ public class ConnectorGenerator {
      * @param outputDir The output directory.
      * @return The path to the generated connector.
      */
-    // Add miVersion default value to 4.4.0
+    public static String generateConnector(String openApiSpec, String outputDir) {
+        return generateConnector(openApiSpec, outputDir, "4.3.0");
+    }
+
+    /**
+     * Generates the connector using the OpenAPI spec.
+     *
+     * @param openApiSpec The OpenAPI spec.
+     * @param outputDir The output directory.
+     * @param miVersion The MI version (default is 4.4.0 if not provided).
+     * @return The path to the generated connector.
+     */
     public static String generateConnector(String openApiSpec, String outputDir, String miVersion) {
-        if (miVersion == null) {
-            miVersion = "4.4.0";
-        }
+        return generateConnectorInternal(openApiSpec, outputDir, miVersion);
+    }
+
+    private static String generateConnectorInternal(String openApiSpec, String outputDir, String miVersion) {
         String connectorPath;
         try {
             String connectorProjectDir = ProjectGeneratorUtils.generateConnectorProject(openApiSpec, outputDir, miVersion);
-            connectorPath =  ConnectorBuilderUtils.buildConnector(connectorProjectDir);
+            connectorPath = ConnectorBuilderUtils.buildConnector(connectorProjectDir);
         } catch (ConnectorGenException e) {
             throw new RuntimeException("Error occurred while generating the connector", e);
         }

--- a/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/ConnectorGenerator.java
+++ b/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/ConnectorGenerator.java
@@ -58,7 +58,7 @@ public class ConnectorGenerator {
         }
         String connectorPath;
         try {
-            String connectorProjectDir = ProjectGeneratorUtils.generateConnectorProject(openApiSpec, outputDir,miVersion);
+            String connectorProjectDir = ProjectGeneratorUtils.generateConnectorProject(openApiSpec, outputDir, miVersion);
             connectorPath =  ConnectorBuilderUtils.buildConnector(connectorProjectDir);
         } catch (ConnectorGenException e) {
             throw new RuntimeException("Error occurred while generating the connector", e);

--- a/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/Constants.java
+++ b/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/Constants.java
@@ -34,4 +34,5 @@ public class Constants {
     public static final String OP_CONTENT_TYPE = "contentType";
     public static final String OS_WINDOWS = "windows";
     public static final String MAVEN_GOALS = "clean install";
+    public static final String HAS_RESPONSE_MODEL = "hasResponseModel";
 }

--- a/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/utils/ConnectorBuilderUtils.java
+++ b/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/utils/ConnectorBuilderUtils.java
@@ -26,11 +26,11 @@ public class ConnectorBuilderUtils {
     private static final Log log = LogFactory.getLog(ConnectorBuilderUtils.class);
     private static final Invoker invoker = new DefaultInvoker();;
 
-    public String build(String openAPISpecPath, String projectPath) {
+    public String build(String openAPISpecPath, String projectPath, String miVersion) {
         String connectorPath = null;
         try {
             ProjectGeneratorUtils connectorProjectGenerator = new ProjectGeneratorUtils();
-            String connectorProjectPath = connectorProjectGenerator.generateConnectorProject(openAPISpecPath, projectPath);
+            String connectorProjectPath = connectorProjectGenerator.generateConnectorProject(openAPISpecPath, projectPath, miVersion);
             connectorPath = buildConnector(connectorProjectPath);
         } catch (ConnectorGenException e) {
             log.error("Error occurred while building the connector.", e);

--- a/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/utils/ProjectGeneratorUtils.java
+++ b/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/utils/ProjectGeneratorUtils.java
@@ -95,9 +95,9 @@ public class ProjectGeneratorUtils {
                         "/src/main/java/org/wso2/carbon/" + connectorName + "connector";
                 String pathToResourcesDir = pathToConnectorDir + "/src/main/resources";
                 createConnectorDirectory(pathToConnectorDir, pathToMainDir, pathToResourcesDir, connectorName);
-                context.put("hasResponseModel", false);
+                context.put(Constants.HAS_RESPONSE_MODEL, false);
                 if (miVersion != null && miVersion.compareTo("4.4.0") >= 0) {
-                    context.put("hasResponseModel", true);
+                    context.put(Constants.HAS_RESPONSE_MODEL, true);
                 }
                 copyConnectorStaticFiles(pathToConnectorDir, pathToResourcesDir, pathToMainDir);
                 if (openAPI.getComponents() != null) {
@@ -139,7 +139,7 @@ public class ProjectGeneratorUtils {
         Files.createDirectories(Paths.get(pathToResourcesDir + "/functions"));
         Files.createDirectories(Paths.get(pathToResourcesDir + "/icon"));
         Files.createDirectories(Paths.get(pathToResourcesDir + "/uischema"));
-        if ("true".equals(String.valueOf(context.get("hasResponseModel")))) {
+        if ("true".equals(String.valueOf(context.get(Constants.HAS_RESPONSE_MODEL)))) {
             Files.createDirectories(Paths.get(pathToResourcesDir + "/outputschema"));
         }
         
@@ -552,7 +552,7 @@ public class ProjectGeneratorUtils {
         String uischemaFileName = pathToResourcesDir + "/uischema/" + operationName + ".json";
         mergeVelocityTemplate(synapseFileName, "templates/synapse/function_template.vm");
         mergeVelocityTemplate(uischemaFileName, "templates/uischema/operation_template.vm");
-        if (context.get("hasResponseModel").equals("true")) {
+        if (context.get(Constants.HAS_RESPONSE_MODEL).equals("true")) {
             String outputSchemaFileName = pathToResourcesDir + "/outputschema/" + operationName + ".json";
             mergeVelocityTemplate(outputSchemaFileName, "templates/outputschema/operation_response_schema_template.vm");
         }

--- a/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/utils/ProjectGeneratorUtils.java
+++ b/src/main/java/org/wso2/mi/tool/connector/tools/generator/openapi/utils/ProjectGeneratorUtils.java
@@ -73,7 +73,7 @@ public class ProjectGeneratorUtils {
     static VelocityContext context;
     static Map<String, Schema> componentsSchema;
 
-    public static String generateConnectorProject(String openAPISpecPath, String projectPath) throws
+    public static String generateConnectorProject(String openAPISpecPath, String projectPath, String miVersion) throws
             ConnectorGenException {
 
         String pathToConnectorDir = null;
@@ -95,6 +95,10 @@ public class ProjectGeneratorUtils {
                         "/src/main/java/org/wso2/carbon/" + connectorName + "connector";
                 String pathToResourcesDir = pathToConnectorDir + "/src/main/resources";
                 createConnectorDirectory(pathToConnectorDir, pathToMainDir, pathToResourcesDir, connectorName);
+                context.put("hasResponseModel", false);
+                if (miVersion != null && miVersion.compareTo("4.4.0") >= 0) {
+                    context.put("hasResponseModel", true);
+                }
                 copyConnectorStaticFiles(pathToConnectorDir, pathToResourcesDir, pathToMainDir);
                 if (openAPI.getComponents() != null) {
                     componentsSchema = openAPI.getComponents().getSchemas();
@@ -135,7 +139,10 @@ public class ProjectGeneratorUtils {
         Files.createDirectories(Paths.get(pathToResourcesDir + "/functions"));
         Files.createDirectories(Paths.get(pathToResourcesDir + "/icon"));
         Files.createDirectories(Paths.get(pathToResourcesDir + "/uischema"));
-        Files.createDirectories(Paths.get(pathToResourcesDir + "/outputschema"));
+        if ("true".equals(String.valueOf(context.get("hasResponseModel")))) {
+            Files.createDirectories(Paths.get(pathToResourcesDir + "/outputschema"));
+        }
+        
     }
 
     private static void createAssemblyDirectory(String assemblyDirPath) {
@@ -543,10 +550,12 @@ public class ProjectGeneratorUtils {
         context.put(Constants.OPERATION, operationLocal);
         String synapseFileName = pathToResourcesDir + "/functions/" + operationName + ".xml";
         String uischemaFileName = pathToResourcesDir + "/uischema/" + operationName + ".json";
-        String outputSchemaFileName = pathToResourcesDir + "/outputschema/" + operationName + ".json";
         mergeVelocityTemplate(synapseFileName, "templates/synapse/function_template.vm");
         mergeVelocityTemplate(uischemaFileName, "templates/uischema/operation_template.vm");
-        mergeVelocityTemplate(outputSchemaFileName, "templates/outputschema/operation_response_schema_template.vm");
+        if (context.get("hasResponseModel").equals("true")) {
+            String outputSchemaFileName = pathToResourcesDir + "/outputschema/" + operationName + ".json";
+            mergeVelocityTemplate(outputSchemaFileName, "templates/outputschema/operation_response_schema_template.vm");
+        }
     }
 
     private static void readschema(String pathToResourcesDir, String operationName, Operation operationLocal,

--- a/src/main/resources/templates/outputschema/operation_response_schema_template.vm
+++ b/src/main/resources/templates/outputschema/operation_response_schema_template.vm
@@ -11,7 +11,7 @@
             "type": "object",
             "description": "Payload of the API response.",
             "additionalProperties": true
-        }
+        },
       #end
       "attributes": {
         "type": "object",

--- a/src/main/resources/templates/synapse/function_template.vm
+++ b/src/main/resources/templates/synapse/function_template.vm
@@ -59,8 +59,10 @@
             <parameter name="$param.getParameterName()" #if ($param.getXmlDescription()) description="$param.getXmlDescription()" #end/>
         #end
     #end
-    <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
-    <parameter name="overwriteBody" description="Replace the Message Body in Message Context with the response of the operation."/>
+    #if ($hasResponseModel==true)
+        <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
+        <parameter name="overwriteBody" description="Replace the Message Body in Message Context with the response of the operation."/>
+    #end
     <sequence>
         <class name="org.wso2.carbon.${connectorName}connector.RestURLBuilder">
             <property name="operationPath" value="$operation.getPath()"/>

--- a/src/main/resources/templates/uischema/operation_template.vm
+++ b/src/main/resources/templates/uischema/operation_template.vm
@@ -123,13 +123,13 @@
                     ,{
                         "type":"attributeGroup",
                         "value":{
-                            "groupName": "Response",
+                            "groupName": "Output",
                             "elements":[
                                 {
                                     "type":"attribute",
                                     "value":{
                                         "name": "responseVariable",
-                                        "displayName": "Target",
+                                        "displayName": "Output Variable Name",
                                         "inputType": "string",
                                         "deriveResponseVariable" : true,
                                         "required": "true",
@@ -143,7 +143,7 @@
                                         "displayName": "Replace Message Body",
                                         "inputType": "checkbox",
                                         "defaultValue": "false",
-                                        "helpTip": "Replace the Message Body in Message Context with the response of the operation.",
+                                        "helpTip": "Replace the Message Body in Message Context with the output of the operation (This will remove the payload from the above variable).",
                                         "required": "false"
                                     }
                                 }

--- a/src/main/resources/templates/uischema/operation_template.vm
+++ b/src/main/resources/templates/uischema/operation_template.vm
@@ -119,6 +119,7 @@
                         }
                     }
                     #end
+                    #if ($hasResponseModel==true)
                     ,{
                         "type":"attributeGroup",
                         "value":{
@@ -149,6 +150,7 @@
                             ]
                         }
                     }
+                    #end
                 ]
             }
         }


### PR DESCRIPTION
### Description

This PR updates the connector generator tool to ensure that variables related to the new response model (introduced in 4.4.0) are not generated in projects using MI 4.3.0. This prevents compatibility issues and ensures correct code generation for different versions.

This is done by introducing a new parameter to the `generateConnectorProject` ;
```java 
generateConnectorProject(String openAPISpecPath, String projectPath, String miVersion)
```

For the 4.3.0-based projects ```miVersion``` should be set to ```4.3.0``` and the generator will not be generating any output schema. If the parameter is not given it will be defaultly set to ```4.4.0```.